### PR TITLE
Fixed 'fileFullPath' error on upgrades and refactored code.

### DIFF
--- a/ImDisk-Toolkit/tools/chocolateyBeforeModify.ps1
+++ b/ImDisk-Toolkit/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Stop'
+
+$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+$toolkitPath = Join-Path -Path $toolsPath -ChildPath 'toolkit'
+
+# this will remove older versions that are not installed to the new $toolkitPath
+if (Test-Path -Path (Join-Path -Path $toolsPath -ChildPath 'config.exe')) {
+    Get-ChildItem -Path $toolspath -Exclude 'chocolatey*.ps1' | Remove-Item -Recurse -ErrorAction SilentlyContinue
+}
+else {
+    Get-ChildItem -Path $toolkitPath -Recurse | Remove-Item -Recurse -ErrorAction SilentlyContinue
+}

--- a/ImDisk-Toolkit/tools/chocolateyInstall.ps1
+++ b/ImDisk-Toolkit/tools/chocolateyInstall.ps1
@@ -1,23 +1,28 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+$toolkitPath = Join-Path -Path $toolsPath -ChildPath 'toolkit'
 $silentArgs     = '/fullsilent'
 
 $packageArgs = @{
   packageName    = 'ImDisk-Toolkit'
   softwareName   = 'imdisk-toolkit*'
   fileType       = 'zip'
-  file           = gi $toolsPath\*_x32.zip
-  file64         = gi $toolsPath\*_x64.zip
+  file           = Get-Item -Path (Join-Path -Path $toolsPath -ChildPath '*_x32.zip')
+  file64         = Get-Item -Path (Join-Path -Path $toolsPath -ChildPath '*_x64.zip')
 
   validExitCodes = @(0)
   destination    = $toolsPath
 }
+
 Get-ChocolateyUnzip @packageArgs
-Get-ChocolateyUnzip (Get-ChildItem $toolsPath\*.cab -Recurse) $toolsPath
 
-Remove-Item $toolsPath\*.zip -ea 0
+$cabFiles = Get-ChildItem -Path $toolsPath\*.cab -Recurse | Sort-Object -Descending | Select-Object -First 1
+Get-ChocolateyUnzip -FileFullPath $cabFiles -Destination $toolkitPath
+Remove-Item -Path $toolsPath\*.zip -ErrorAction SilentlyContinue
 
-$FileFullPath = Get-ChildItem $toolsPath -Recurse -Include config.exe | Sort-Object -Descending | Select-Object -First 1
+$installer = Get-ChildItem -Path (Join-Path -Path $toolkitPath -ChildPath 'config.exe')
+Start-ChocolateyProcessAsAdmin -Statements $silentArgs -ExeToRun $installer
 
-Start-ChocolateyProcess $silentArgs $FileFullPath
+# Remove the folder that contains the .cab file
+Get-ChildItem -Path (Join-Path -Path $toolsPath -ChildPath 'ImDiskTk*') | Where-Object PSIsContainer -eq $true | Remove-Item -Recurse -ErrorAction SilentlyContinue

--- a/ImDisk-Toolkit/tools/chocolateyUninstall.ps1
+++ b/ImDisk-Toolkit/tools/chocolateyUninstall.ps1
@@ -1,6 +1,12 @@
-﻿$packageName = 'imdisk-toolkit'
-$fileType = 'exe'
-$silentArgs = " /silentuninstall"
+﻿$ErrorActionPreference = 'Stop'
+
 $uninstall = Get-UninstallRegistryKey -softwareName "ImDisk Toolkit"
 
-Uninstall-ChocolateyPackage -packageName $packageName -fileType $fileType -silentArgs $silentArgs -file $uninstall.UninstallString.TrimEnd("/u").replace('"','')
+$packageArgs = @{
+    PackageName = $env:ChocolateyPackageName
+    FileType    = 'EXE'
+    SilentArgs  = ' /silentuninstall'
+    File        = $uninstall.UninstallString.TrimEnd("/u").replace('"', '')
+}
+
+Uninstall-ChocolateyPackage @packageArgs


### PR DESCRIPTION
The 'fileFullPath' error outlined [in the Disqus comment on the package page](https://chocolatey.org/packages/imdisk-toolkit#comment-4953491071) (and a previous private message I'd sent) only occurred during upgrade. This was due to it finding the old .CAB files and trying to pass an array to `Get-ChocolateyUnzip` which only accepted a string.

I refactored the code to hopefully allow it to be managed more easily. Newer versions now keep everything in 'toolkit' as opposed to the tools folder. So we can now remove the 'toolkit' folder at upgrade which removes everything knowing that whatever is in there can only be part of the install.

I also refactored some code just to make it easier to understand for the Chocolatey moderators, stopped the Chocolatey Automatic Uninstaller from doing it's thing (as we don't need it to) and created a `chocolateyBeforeModify.ps1` to 'uninstall' previous versions before we install the new one.

I've tested the install, upgrade and uninstall and it all seems to work (on my machine). 

All that is left is for a package fix version to be pushed which I will leave you to do.